### PR TITLE
Feature/TAO-10019/Remove PHPUnit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,6 @@
     ],
     "minimum-stability" : "dev",
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
-        "phpunit/php-code-coverage": "2.*",
         "oat-sa/generis": "*"
     }
 }


### PR DESCRIPTION
Related to: [https://oat-sa.atlassian.net/browse/TAO-10019](https://oat-sa.atlassian.net/browse/TAO-10019)

Remove PHPUnit dependency from package:

- The PHPUnit dependency was removed from the **require-dev** section.