### PR TITLE
Breaking/dpf 514/authentication cache updates

### DIFF
--- a/bin/taoDatabaseMigration.php
+++ b/bin/taoDatabaseMigration.php
@@ -1,21 +1,21 @@
 <?php
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- * 
+ *
  */
 
 $parms = $argv;
@@ -31,5 +31,5 @@ $rawStart = $root.'tao'.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR.'raw_
 
 require_once $rawStart;
 
-oat\authKeyValue\helpers\DataMigration::fromOntologyToKey();
+oat\authKeyValue\helpers\OntologyDataMigration::migrateAllUsers();
 echo 'migration done'.PHP_EOL;

--- a/src/AuthKeyValueAdapter.php
+++ b/src/AuthKeyValueAdapter.php
@@ -1,22 +1,22 @@
 <?php
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *               
- * 
+ *
+ *
  */
 
 /**
@@ -24,7 +24,7 @@
  *
  * @author christophe massin
  * @package authKeyValue
- 
+
  */
 
 namespace oat\authKeyValue;
@@ -38,7 +38,7 @@ use oat\generis\model\GenerisRdf;
 
 /**
  * Adapter to authenticate users stored in the key value implementation
- * 
+ *
  * @author Christophe Massin <christope@taotesting.com>
  *
  */
@@ -97,12 +97,16 @@ class AuthKeyValueAdapter extends Configurable implements LoginAdapter
             $user = new AuthKeyValueUser();
             $user->setConfiguration($this->getOptions());
             $user->setIdentifier($params['uri']);
-            $user->setLanguageUi($params[GenerisRdf::PROPERTY_USER_UILG]);
-            $user->setLanguageDefLg($params[GenerisRdf::PROPERTY_USER_DEFLG]);
+            if (isset($params[GenerisRdf::PROPERTY_USER_UILG])) {
+                $user->setLanguageUi($params[GenerisRdf::PROPERTY_USER_UILG]);
+            }
+            if (isset($params[GenerisRdf::PROPERTY_USER_DEFLG])) {
+                $user->setLanguageDefLg($params[GenerisRdf::PROPERTY_USER_DEFLG]);
+            }
             $user->setUserRawParameters($params);
-            
+
             return $user;
-            
+
         } else {
             throw new core_kernel_users_InvalidLoginException('User "'.$this->username.'" failed key-value authentication.');
         }

--- a/src/AuthKeyValueUser.php
+++ b/src/AuthKeyValueUser.php
@@ -41,11 +41,11 @@ class AuthKeyValueUser extends common_user_User {
 
     /**
      * Max size of a property to store in the session in characters
-     * 
+     *
      * @var int
      */
     const DEFAULT_MAX_CACHE_SIZE = 1000;
-    
+
     /** @var  array of configuration */
     protected $configuration;
 
@@ -65,15 +65,15 @@ class AuthKeyValueUser extends common_user_User {
     protected $identifier;
 
     /**
-     * Array that contains the language code as a single string  
-     * 
+     * Array that contains the language code as a single string
+     *
      * @var array
      */
     protected $languageUi = array(DEFAULT_LANG);
 
     /**
      * Array that contains the language code as a single string
-     * 
+     *
      * @var array
      */
     protected $languageDefLg = array(DEFAULT_LANG);
@@ -96,7 +96,7 @@ class AuthKeyValueUser extends common_user_User {
 
     /**
      * Sets the language URI
-     * 
+     *
      * @param string $languageDefLgUri
      */
     public function setLanguageDefLg($languageDefLgUri)
@@ -113,7 +113,7 @@ class AuthKeyValueUser extends common_user_User {
 
     /**
      * Returns the language code
-     * 
+     *
      * @return array
      */
     public function getLanguageDefLg()
@@ -239,12 +239,13 @@ class AuthKeyValueUser extends common_user_User {
                 $login = reset($userParameters[GenerisRdf::PROPERTY_USER_LOGIN]);
                 $value = $serviceUser->getUserParameter($login, $property);
 
-                if( strlen(base64_encode(serialize($value))) < $this->getMaxCacheSize() ) {
-                    $extraParameters[$property] = $value;
-                    $this->setUserExtraParameters($extraParameters);
+                if (!empty($value)) {
+                    if( strlen(base64_encode(serialize($value))) < $this->getMaxCacheSize() ) {
+                        $extraParameters[$property] = $value;
+                        $this->setUserExtraParameters($extraParameters);
+                    }
+                    $returnValue = array($value);
                 }
-
-                $returnValue = array($value);
             }
 
         }
@@ -265,17 +266,17 @@ class AuthKeyValueUser extends common_user_User {
         $params = json_decode($userData[AuthKeyValueUserService::USER_PARAMETERS],true);
         $this->setUserRawParameters($params);
     }
-    
+
     protected function getPersistenceId() {
         $config = $this->getConfiguration();
         return isset($config[AuthKeyValueAdapter::OPTION_PERSISTENCE])
             ? $config[AuthKeyValueAdapter::OPTION_PERSISTENCE]
             : AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID;
     }
-    
+
     protected function getMaxCacheSize() {
         $config = $this->getConfiguration();
-        return isset($config['max_size_cached_element']) ? $config['max_size_cached_element'] : self::DEFAULT_MAX_CACHE_SIZE; 
+        return isset($config['max_size_cached_element']) ? $config['max_size_cached_element'] : self::DEFAULT_MAX_CACHE_SIZE;
     }
 
 }

--- a/src/action/DataMigrationAction.php
+++ b/src/action/DataMigrationAction.php
@@ -22,7 +22,7 @@ namespace oat\authKeyValue\action;
 
 use oat\oatbox\action\Action;
 use oat\authKeyValue\AuthKeyValueAdapter;
-use oat\authKeyValue\helpers\DataMigration;
+use oat\authKeyValue\helpers\OntologyDataMigration;
 
 class DataMigrationAction implements Action
 {
@@ -35,7 +35,7 @@ class DataMigrationAction implements Action
     public function __invoke($params)
     {
         $persistenceId = count($params) > 0 ? array_shift($params) : AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID;
-        DataMigration::fromOntologyToKey($persistenceId);
+        OntologyDataMigration::migrateAllUsers($persistenceId);
         return \common_report_Report::createSuccess(__('User migrated from ontology to KeyValue storage'));
     }
 }

--- a/src/action/RegisterUserEventListener.php
+++ b/src/action/RegisterUserEventListener.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\authKeyValue\action;
+
+use common_persistence_Manager;
+use common_report_Report;
+use oat\authKeyValue\AuthKeyValueAdapter;
+use oat\authKeyValue\listener\UserListener;
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\event\UserRemovedEvent;
+use oat\tao\model\event\UserUpdatedEvent;
+
+class RegisterUserEventListener extends InstallAction
+{
+    /**
+     * Register events to keep authentication cache up to date
+     *
+     * @param $params
+     * @return common_report_Report
+     */
+    public function __invoke($params)
+    {
+        /** @var common_persistence_Manager $persistenceManager */
+        $persistenceManager = $this->getServiceLocator()->get(common_persistence_Manager::SERVICE_ID);
+        if (!$persistenceManager->hasPersistence(AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID)) {
+            return common_report_Report::createFailure(
+                'Action failed. "' . AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID . '" persistence configuration is missing.'
+            );
+        }
+
+        $this->registerEvent(UserUpdatedEvent::class, [UserListener::class, 'updateUser']);
+        $this->registerEvent(UserRemovedEvent::class, [UserListener::class, 'removeUser']);
+
+        return common_report_Report::createSuccess(
+            'User event listener successfully configured to update key value authentication cache.'
+        );
+    }
+}

--- a/src/helpers/OntologyDataMigration.php
+++ b/src/helpers/OntologyDataMigration.php
@@ -8,74 +8,70 @@
 
 namespace oat\authKeyValue\helpers;
 
-use common_persistence_AdvKeyValuePersistence;
 use oat\authKeyValue\AuthKeyValueAdapter;
 use tao_models_classes_UserService;
 use oat\authKeyValue\AuthKeyValueUserService;
-use core_kernel_users_Service;
 use oat\generis\model\GenerisRdf;
 
 class OntologyDataMigration
 {
 
-    public static function fromOntologyToKey($persistenceID = AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID)
+    public static function migrateAllUsers($persistenceID = AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID)
     {
-        $kvStore = common_persistence_AdvKeyValuePersistence::getPersistence($persistenceID);
         $service = tao_models_classes_UserService::singleton();
         $users = $service->getAllUsers();
 
         foreach ($users as $user) {
-            $userParameterFormatedForDb = array();
-            $userParameterFormatedForDbExtraParameters = array();
-            $userParameterFormatedForDb['uri'] = $user->getUri();
+            self::migrateUser($user, $persistenceID);
+        }
+    }
 
-            $userData = $user->getRdfTriples();
+    public static function migrateUser($user, $persistenceID = AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID)
+    {
+        $service = new AuthKeyValueUserService($persistenceID);
 
-            foreach ($userData as $property) {
-                switch ($property->predicate) {
-                    case GenerisRdf::PROPERTY_USER_LOGIN :
-                        $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_LOGIN] = $property->object;
-                        $login = $property->object;
-                        break;
-                    case GenerisRdf::PROPERTY_USER_PASSWORD :
-                        $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_PASSWORD] = $property->object;
-                        $password = $property->object;
-                        break;
-                    case GenerisRdf::PROPERTY_USER_ROLES :
-                        $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_ROLES][] = $property->object;
-                        break;
-                    case GenerisRdf::PROPERTY_USER_UILG :
-                        $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_UILG] = $property->object;
-                        break;
-                    case GenerisRdf::PROPERTY_USER_DEFLG :
-                        $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_DEFLG] = $property->object;
-                        break;
-                    case GenerisRdf::PROPERTY_USER_FIRSTNAME :
-                        $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_FIRSTNAME] = $property->object;
-                        break;
-                    case GenerisRdf::PROPERTY_USER_LASTNAME :
-                        $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_LASTNAME] = $property->object;
-                        break;
-                    default :
-                        $userParameterFormatedForDbExtraParameters[$property->predicate] = $property->object;
-                }
-            }
+        $userParameterFormatedForDb = [];
+        $userParameterFormatedForDbExtraParameters = [];
+        $userParameterFormatedForDb['uri'] = $user->getUri();
 
+        $userData = $user->getRdfTriples();
 
-            $kvStore->getDriver()->hSet(
-                AuthKeyValueUserService::PREFIXES_KEY . ':' . $login,
-                GenerisRdf::PROPERTY_USER_PASSWORD,
-                $password
-            );
-            $kvStore->getDriver()->hSet(
-                AuthKeyValueUserService::PREFIXES_KEY . ':' . $login,
-                'parameters',
-                json_encode($userParameterFormatedForDb)
-            );
-
-            foreach ($userParameterFormatedForDbExtraParameters as $key => $value) {
-                $kvStore->getDriver()->set(AuthKeyValueUserService::PREFIXES_KEY . ':' . $login . ':' . $key, $value);
+        foreach ($userData as $property) {
+            switch ($property->predicate) {
+                case GenerisRdf::PROPERTY_USER_LOGIN :
+                    $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_LOGIN] = $property->object;
+                    $login = $property->object;
+                    break;
+                case GenerisRdf::PROPERTY_USER_PASSWORD :
+                    $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_PASSWORD] = $property->object;
+                    $password = $property->object;
+                    break;
+                case GenerisRdf::PROPERTY_USER_ROLES :
+                    $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_ROLES][] = $property->object;
+                    break;
+                case GenerisRdf::PROPERTY_USER_UILG :
+                    $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_UILG] = $property->object;
+                    break;
+                case GenerisRdf::PROPERTY_USER_DEFLG :
+                    $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_DEFLG] = $property->object;
+                    break;
+                case GenerisRdf::PROPERTY_USER_FIRSTNAME :
+                    $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_FIRSTNAME] = $property->object;
+                    break;
+                case GenerisRdf::PROPERTY_USER_LASTNAME :
+                    $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_LASTNAME] = $property->object;
+                    break;
+                default :
+                    $userParameterFormatedForDbExtraParameters[$property->predicate] = $property->object;
             }
         }
+
+        $service->removeUserData($login);
+        $service->storeUserData(
+            $login,
+            $password,
+            $userParameterFormatedForDb,
+            $userParameterFormatedForDbExtraParameters
+        );
     }
 }

--- a/src/helpers/OntologyDataMigration.php
+++ b/src/helpers/OntologyDataMigration.php
@@ -15,27 +15,24 @@ use oat\authKeyValue\AuthKeyValueUserService;
 use core_kernel_users_Service;
 use oat\generis\model\GenerisRdf;
 
-class DataMigration {
+class OntologyDataMigration
+{
 
     public static function fromOntologyToKey($persistenceID = AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID)
     {
-
-
         $kvStore = common_persistence_AdvKeyValuePersistence::getPersistence($persistenceID);
         $service = tao_models_classes_UserService::singleton();
         $users = $service->getAllUsers();
 
-        foreach( $users as $user){
-
+        foreach ($users as $user) {
             $userParameterFormatedForDb = array();
             $userParameterFormatedForDbExtraParameters = array();
             $userParameterFormatedForDb['uri'] = $user->getUri();
 
             $userData = $user->getRdfTriples();
 
-            foreach($userData as $property){
-
-                switch($property->predicate){
+            foreach ($userData as $property) {
+                switch ($property->predicate) {
                     case GenerisRdf::PROPERTY_USER_LOGIN :
                         $userParameterFormatedForDb[GenerisRdf::PROPERTY_USER_LOGIN] = $property->object;
                         $login = $property->object;
@@ -61,20 +58,24 @@ class DataMigration {
                         break;
                     default :
                         $userParameterFormatedForDbExtraParameters[$property->predicate] = $property->object;
-
                 }
-
             }
 
 
-            $kvStore->getDriver()->hSet(AuthKeyValueUserService::PREFIXES_KEY.':'.$login, GenerisRdf::PROPERTY_USER_PASSWORD, $password);
-            $kvStore->getDriver()->hSet(AuthKeyValueUserService::PREFIXES_KEY.':'.$login, 'parameters', json_encode($userParameterFormatedForDb));
+            $kvStore->getDriver()->hSet(
+                AuthKeyValueUserService::PREFIXES_KEY . ':' . $login,
+                GenerisRdf::PROPERTY_USER_PASSWORD,
+                $password
+            );
+            $kvStore->getDriver()->hSet(
+                AuthKeyValueUserService::PREFIXES_KEY . ':' . $login,
+                'parameters',
+                json_encode($userParameterFormatedForDb)
+            );
 
-            foreach($userParameterFormatedForDbExtraParameters as $key => $value ) {
-                $kvStore->getDriver()->set(AuthKeyValueUserService::PREFIXES_KEY.':'.$login.':'.$key, $value);
+            foreach ($userParameterFormatedForDbExtraParameters as $key => $value) {
+                $kvStore->getDriver()->set(AuthKeyValueUserService::PREFIXES_KEY . ':' . $login . ':' . $key, $value);
             }
-
         }
-
     }
-} 
+}

--- a/src/listener/UserListener.php
+++ b/src/listener/UserListener.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\authKeyValue\listener;
+
+use oat\authKeyValue\AuthKeyValueUserService;
+use oat\authKeyValue\helpers\OntologyDataMigration;
+use oat\tao\model\event\UserRemovedEvent;
+use oat\tao\model\event\UserUpdatedEvent;
+
+class UserListener
+{
+    public static function updateUser(UserUpdatedEvent $event)
+    {
+        $eventData = $event->jsonSerialize();
+        if (isset($eventData['uri'])) {
+            OntologyDataMigration::migrateUser(new \core_kernel_classes_Resource($eventData['uri']));
+        }
+    }
+
+    public static function removeUser(UserRemovedEvent $event)
+    {
+        $eventData = $event->jsonSerialize();
+        if (isset($eventData['login'])) {
+            $service = new AuthKeyValueUserService();
+            $service->removeUserData($eventData['login']);
+        }
+    }
+}


### PR DESCRIPTION
Key value authentication adapter changes, to invalidate/update/cache user data when user account is deleted/updated/created. 
 
Related to : https://oat-sa.atlassian.net/browse/DPF-514
 
On `UserUpdatedEvent` user authentication cache is populated from ontology. On `UserRemovedEvent` associated records in authentication cache are deleted. Storage of user data has been modified to support record deletion.
  
#### How to test

- Configure `oat\authKeyValue\AuthKeyValueAdapter` as a first entry in `config/generis/auth.conf.php`
- Configure `authKeyValue` persistence in `config/generis/persistences.conf.php`
- Register user event listener with `php index.php 'oat\authKeyValue\action\RegisterUserEventListener'`
- Verify that creating/updating a user populates the authentication cache, removing a user deletes associated records in the cache.
- Logging in as a test taker and passing an assigned test center delivery is working correctly.
 
  
#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/tao-core/tree/breaking/DPF-514/user-removed-event-login
  