### PR TITLE
Bugfix/RO-414 Store group data properly

### DIFF
--- a/src/AuthKeyValueUser.php
+++ b/src/AuthKeyValueUser.php
@@ -159,7 +159,6 @@ class AuthKeyValueUser extends common_user_User {
         return $this->userRawParameters;
     }
 
-
     /**
      * @param mixed $language
      */
@@ -183,7 +182,6 @@ class AuthKeyValueUser extends common_user_User {
         return $this->languageUi;
     }
 
-
     /**
      * @return string
      */
@@ -200,7 +198,6 @@ class AuthKeyValueUser extends common_user_User {
 
         return $this;
     }
-
 
     /**
      * @param $property string
@@ -228,11 +225,7 @@ class AuthKeyValueUser extends common_user_User {
             $extraParameters = $this->getUserExtraParameters();
             // the element has already been accessed
             if(!empty($extraParameters) && array_key_exists($property, $extraParameters)){
-                if(!is_array($extraParameters[$property])){
-                    $returnValue = array($extraParameters[$property]);
-                } else {
-                    $returnValue = $extraParameters[$property];
-                }
+                $returnValue = array($extraParameters[$property]);
             } else {
                 // not already accessed, we are going to get it.
                 $login = reset($userParameters[GenerisRdf::PROPERTY_USER_LOGIN]);
@@ -247,12 +240,17 @@ class AuthKeyValueUser extends common_user_User {
                 }
             }
 
-            $returnValue = json_decode(current($returnValue), true);
+            if (!empty($returnValue)) {
+                $returnValue = json_decode(current($returnValue), true);
+
+                if (!is_array($returnValue)) {
+                    $returnValue = [$returnValue];
+                }
+            }
         }
 
         return $returnValue;
     }
-
 
     /**
      * Function that will refresh the parameters.

--- a/src/AuthKeyValueUser.php
+++ b/src/AuthKeyValueUser.php
@@ -233,7 +233,6 @@ class AuthKeyValueUser extends common_user_User {
                 } else {
                     $returnValue = $extraParameters[$property];
                 }
-
             } else {
                 // not already accessed, we are going to get it.
                 $login = reset($userParameters[GenerisRdf::PROPERTY_USER_LOGIN]);
@@ -247,6 +246,8 @@ class AuthKeyValueUser extends common_user_User {
                     $returnValue = array($value);
                 }
             }
+
+            $returnValue = json_decode(current($returnValue), true);
         }
 
         return $returnValue;

--- a/src/AuthKeyValueUserService.php
+++ b/src/AuthKeyValueUserService.php
@@ -84,7 +84,7 @@ class AuthKeyValueUserService extends ConfigurableService
             $this->getPersistence()->hSet(
                 $this->getParameterStorageKey($login),
                 $property,
-                $value
+                json_encode($value)
             );
         }
     }

--- a/src/helpers/OntologyDataMigration.php
+++ b/src/helpers/OntologyDataMigration.php
@@ -19,9 +19,9 @@
 
 namespace oat\authKeyValue\helpers;
 
+use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
 use oat\oatbox\service\ServiceManager;
-use oat\taoGroups\models\GroupsService;
 use tao_models_classes_UserService;
 use oat\authKeyValue\AuthKeyValueUserService;
 use oat\generis\model\GenerisRdf;
@@ -46,36 +46,39 @@ class OntologyDataMigration
         $userData['uri'] = $userUri;
 
         $user = new core_kernel_classes_Resource($userUri);
-        foreach ($user->getRdfTriples() as $property) {
-            switch ($property->predicate) {
+        foreach ($user->getRdfTriples() as $rdfTriple) {
+            switch ($rdfTriple->predicate) {
                 case GenerisRdf::PROPERTY_USER_LOGIN :
-                    $userData[GenerisRdf::PROPERTY_USER_LOGIN] = $property->object;
-                    $login = $property->object;
+                    $userData[GenerisRdf::PROPERTY_USER_LOGIN] = $rdfTriple->object;
+                    $login = $rdfTriple->object;
                     break;
                 case GenerisRdf::PROPERTY_USER_PASSWORD :
-                    $userData[GenerisRdf::PROPERTY_USER_PASSWORD] = $property->object;
-                    $password = $property->object;
+                    $userData[GenerisRdf::PROPERTY_USER_PASSWORD] = $rdfTriple->object;
+                    $password = $rdfTriple->object;
                     break;
                 case GenerisRdf::PROPERTY_USER_ROLES :
-                    $userData[GenerisRdf::PROPERTY_USER_ROLES][] = $property->object;
+                    $userData[GenerisRdf::PROPERTY_USER_ROLES][] = $rdfTriple->object;
                     break;
                 case GenerisRdf::PROPERTY_USER_UILG :
-                    $userData[GenerisRdf::PROPERTY_USER_UILG] = $property->object;
+                    $userData[GenerisRdf::PROPERTY_USER_UILG] = $rdfTriple->object;
                     break;
                 case GenerisRdf::PROPERTY_USER_DEFLG :
-                    $userData[GenerisRdf::PROPERTY_USER_DEFLG] = $property->object;
+                    $userData[GenerisRdf::PROPERTY_USER_DEFLG] = $rdfTriple->object;
                     break;
                 case GenerisRdf::PROPERTY_USER_FIRSTNAME :
-                    $userData[GenerisRdf::PROPERTY_USER_FIRSTNAME] = $property->object;
+                    $userData[GenerisRdf::PROPERTY_USER_FIRSTNAME] = $rdfTriple->object;
                     break;
                 case GenerisRdf::PROPERTY_USER_LASTNAME :
-                    $userData[GenerisRdf::PROPERTY_USER_LASTNAME] = $property->object;
-                    break;
-                case GroupsService::PROPERTY_MEMBERS_URI :
-                    $userData[GroupsService::PROPERTY_MEMBERS_URI][] = $property->object;
+                    $userData[GenerisRdf::PROPERTY_USER_LASTNAME] = $rdfTriple->object;
                     break;
                 default :
-                    $userExtraData[$property->predicate] = $property->object;
+                    $property = new core_kernel_classes_Property($rdfTriple->predicate);
+
+                    if ($property->isMultiple()) {
+                        $userExtraData[$rdfTriple->predicate][] = $rdfTriple->object;
+                    } else {
+                        $userExtraData[$rdfTriple->predicate] = $rdfTriple->object;
+                    }
             }
         }
 

--- a/src/helpers/OntologyDataMigration.php
+++ b/src/helpers/OntologyDataMigration.php
@@ -21,6 +21,7 @@ namespace oat\authKeyValue\helpers;
 
 use core_kernel_classes_Resource;
 use oat\oatbox\service\ServiceManager;
+use oat\taoGroups\models\GroupsService;
 use tao_models_classes_UserService;
 use oat\authKeyValue\AuthKeyValueUserService;
 use oat\generis\model\GenerisRdf;
@@ -69,6 +70,9 @@ class OntologyDataMigration
                     break;
                 case GenerisRdf::PROPERTY_USER_LASTNAME :
                     $userData[GenerisRdf::PROPERTY_USER_LASTNAME] = $property->object;
+                    break;
+                case GroupsService::PROPERTY_MEMBERS_URI :
+                    $userData[GroupsService::PROPERTY_MEMBERS_URI][] = $property->object;
                     break;
                 default :
                     $userExtraData[$property->predicate] = $property->object;

--- a/test/unit/AuthKeyValueUserTest.php
+++ b/test/unit/AuthKeyValueUserTest.php
@@ -60,7 +60,10 @@ class AuthKeyValueUserTest extends TestCase
 
     public function testGetPropertyValues_WhenExtraParamAccessedSecondTime_ThenItsReturnedFromCache()
     {
-        $this->authUserService->expects($this->once())->method('getUserParameter')->willReturn('extraValue');
+        $this->authUserService
+            ->expects($this->once())
+            ->method('getUserParameter')
+            ->willReturn(json_encode('extraValue'));
         $this->assertEquals(['extraValue'], $this->authUser->getPropertyValues('extraProperty'));
         $this->assertEquals(['extraValue'], $this->authUser->getPropertyValues('extraProperty'));
     }
@@ -68,7 +71,10 @@ class AuthKeyValueUserTest extends TestCase
     public function testGetPropertyValues_WhenExtraParamValueSizeExceedsLimit_ThenItsReadFromPersistence()
     {
         $this->authUser->setConfiguration(['max_size_cached_element' => 1]);
-        $this->authUserService->expects($this->exactly(2))->method('getUserParameter')->willReturn('extraValue');
+        $this->authUserService
+            ->expects($this->exactly(2))
+            ->method('getUserParameter')
+            ->willReturn(json_encode('extraValue'));
         $this->assertEquals(['extraValue'], $this->authUser->getPropertyValues('extraProperty'));
         $this->assertEquals(['extraValue'], $this->authUser->getPropertyValues('extraProperty'));
     }
@@ -84,5 +90,30 @@ class AuthKeyValueUserTest extends TestCase
         $this->authUser->setUserExtraParameters(['testExtraParam' => 'value']);
         $this->authUser->refresh();
         $this->assertEmpty($this->authUser->getUserExtraParameters());
+    }
+
+    public function testGetPropertyValues_WithParamAsArray_ThenItsReturnedFromCache()
+    {
+        $data = ['extraValue1', 'extraValue2'];
+
+        $this->authUserService
+            ->expects($this->once())
+            ->method('getUserParameter')
+            ->willReturn(json_encode($data));
+        $this->assertEquals($data, $this->authUser->getPropertyValues('extraProperty'));
+        $this->assertEquals($data, $this->authUser->getPropertyValues('extraProperty'));
+    }
+
+    public function testGetPropertyValues_WithParamAsArray_ThenItsReadFromPersistence()
+    {
+        $data = ['extraValue1', 'extraValue2'];
+
+        $this->authUser->setConfiguration(['max_size_cached_element' => 1]);
+        $this->authUserService
+            ->expects($this->exactly(2))
+            ->method('getUserParameter')
+            ->willReturn(json_encode($data));
+        $this->assertEquals($data, $this->authUser->getPropertyValues('extraProperty'));
+        $this->assertEquals($data, $this->authUser->getPropertyValues('extraProperty'));
     }
 }


### PR DESCRIPTION
Ticket: [RO-414](https://oat-sa.atlassian.net/browse/RO-414)

When using key value storage, only one group was saved since the group identifier was always replaced on the extra parameters. This was also happening to any property with more than one value. 
To fix it, we are now checking if a property can have multiple values and serializing every entry of the extra_parameters before storing it.

This is what we had before the fix:
```
 1) "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 2) "http://www.tao.lu/Ontologies/TAOSubject.rdf#Subject"
 3) "http://www.tao.lu/Ontologies/TAOGroup.rdf#member"
 4) "https://test-nfer.docker.localhost/ontologies/tao.rdf#i60afb657ce80234247f49b80963a15e"
 5) "http://www.tao.lu/Ontologies/TAO.rdf#UpdatedAt"
 6) "1622632549.4047"
 7) "http://www.tao.lu/Ontologies/generis.rdf#userMail"
 8) "testtaker1@gmail.com"
 9) "http://www.w3.org/2000/01/rdf-schema#label"
10) "Test-taker 1"
```

And then after:

```
1) "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 2) "[\"http:\\/\\/www.tao.lu\\/Ontologies\\/TAOSubject.rdf#Subject\"]"
 3) "http://www.tao.lu/Ontologies/TAOGroup.rdf#member"
 4) "[\"https:\\/\\/test-nfer.docker.localhost\\/ontologies\\/tao.rdf#i60afb7d214d439441f02b086f89837\",\"https:\\/\\/test-nfer.docker.localhost\\/ontologies\\/tao.rdf#i60afb657ce80234247f49b80963a15e\"]"
 5) "http://www.tao.lu/Ontologies/TAO.rdf#UpdatedAt"
 6) "\"1622635010.8946\""
 7) "http://www.tao.lu/Ontologies/generis.rdf#userMail"
 8) "\"testtaker1@gmail.com\""
 9) "http://www.w3.org/2000/01/rdf-schema#label"
10) "\"Test-taker 1\""
```

===========================

UPD:
a couple more PRs added under this ticket. Order of merging:
0) this one;
1) oat-sa/extension-tao-testtaker#180
2) oat-sa/extension-tao-group#141