### PR TITLE
fix: update users cache even if we do update of user resources in tao

### DIFF
--- a/src/action/ActivateKeyValueAuthentication.php
+++ b/src/action/ActivateKeyValueAuthentication.php
@@ -34,6 +34,7 @@ use oat\oatbox\service\exception\InvalidServiceManagerException;
 use oat\oatbox\user\auth\AuthFactory;
 use oat\tao\model\event\UserRemovedEvent;
 use oat\tao\model\event\UserUpdatedEvent;
+use oat\generis\model\data\event\ResourceUpdated;
 
 class ActivateKeyValueAuthentication extends ScriptAction
 {
@@ -123,6 +124,7 @@ class ActivateKeyValueAuthentication extends ScriptAction
     private function registerUserEventListener(): void
     {
         $this->registerEvent(UserUpdatedEvent::class, [UserEventListener::class, 'userUpdated']);
+        $this->registerEvent(ResourceUpdated::class, [UserEventListener::class, 'userUpdated']);
         $this->registerEvent(UserRemovedEvent::class, [UserEventListener::class, 'userRemoved']);
 
         $this->report->add(common_report_Report::createSuccess('User update/remove event listeners registered.'));

--- a/src/listener/UserEventListener.php
+++ b/src/listener/UserEventListener.php
@@ -21,23 +21,47 @@ namespace oat\authKeyValue\listener;
 
 use common_exception_Error;
 use core_kernel_classes_Resource;
+use core_kernel_classes_Property;
 use oat\authKeyValue\AuthKeyValueUserService;
 use oat\authKeyValue\helpers\OntologyDataMigration;
+use oat\generis\model\data\event\ResourceUpdated;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\event\UserRemovedEvent;
 use oat\tao\model\event\UserUpdatedEvent;
+use oat\generis\model\OntologyRdf;
+use oat\tao\model\TaoOntology;
 
 class UserEventListener extends ConfigurableService
 {
     /**
-     * @param UserUpdatedEvent $event
+     * @param UserUpdatedEvent|ResourceUpdated $event
      * @throws common_exception_Error
      */
-    public function userUpdated(UserUpdatedEvent $event)
+    public function userUpdated(UserUpdatedEvent|ResourceUpdated $event)
+    {
+        if ($event instanceof UserUpdatedEvent) {
+            $this->handleUserUpdatedEvent($event);
+        } else {
+            $this->handleResourceUpdatedEvent($event);
+        }
+    }
+    
+    private function handleUserUpdatedEvent(UserUpdatedEvent $event)
     {
         $eventData = $event->jsonSerialize();
         if (isset($eventData['uri'])) {
             OntologyDataMigration::cacheUser($eventData['uri']);
+        }
+    }
+    
+    private function handleResourceUpdatedEvent(ResourceUpdated $event)
+    {
+        $resource = $event->getResource();
+        /** @var core_kernel_classes_Resource $userType */
+        $userType = $resource->getOnePropertyValue(new core_kernel_classes_Property(OntologyRdf::RDF_TYPE));
+        // check if the resource is a user
+        if ($userType->getUri() === TaoOntology::CLASS_URI_TAO_USER) {
+            OntologyDataMigration::cacheUser($resource->getUri());
         }
     }
 

--- a/src/listener/UserEventListener.php
+++ b/src/listener/UserEventListener.php
@@ -34,7 +34,6 @@ use oat\tao\model\TaoOntology;
 class UserEventListener extends ConfigurableService
 {
     /**
-     * @param UserUpdatedEvent|ResourceUpdated $event
      * @throws common_exception_Error
      */
     public function userUpdated(UserUpdatedEvent|ResourceUpdated $event)

--- a/src/listener/UserEventListener.php
+++ b/src/listener/UserEventListener.php
@@ -60,7 +60,7 @@ class UserEventListener extends ConfigurableService
         /** @var core_kernel_classes_Resource $userType */
         $userType = $resource->getOnePropertyValue(new core_kernel_classes_Property(OntologyRdf::RDF_TYPE));
         // check if the resource is a user
-        if ($userType->getUri() === TaoOntology::CLASS_URI_TAO_USER) {
+        if ($userType && $userType->getUri() === TaoOntology::CLASS_URI_TAO_USER) {
             OntologyDataMigration::cacheUser($resource->getUri());
         }
     }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-5961

During update users in Test Center we trigger only the `ResourceUpdated` event as it's a part of the GenerisTree functionality which is not aware of types. 
Because of that, we need to have a new listener of those events which will update the cache if the updated resource is reference to users

![image](https://github.com/oat-sa/generis-auth-keyvalue/assets/1053022/7d95e6f9-dabd-431a-8d23-e28838e1e9ba)

How to test:

1. Run the next command on the existing local environment for switching users to key value storage `php index.php 'oat\authKeyValue\action\ActivateKeyValueAuthentication' --persistence {your key value persistence}` or install the taoPremium extension
2. Create a test center admin user
3. Assign it to any test center like admin and press save on the tree
4. Check that this user will have a proper list of test center after login

For testing:
http://test-authoring-tr-5961.playground.kitchen.it.taocloud.org:40081