### PR TITLE
fix: return always actual ui langiage for users

### DIFF
--- a/src/AuthKeyValueAdapter.php
+++ b/src/AuthKeyValueAdapter.php
@@ -31,7 +31,6 @@ namespace oat\authKeyValue;
 
 use core_kernel_users_Service;
 use core_kernel_users_InvalidLoginException;
-use core_kernel_users_AuthAdapter;
 use oat\oatbox\service\ServiceManager;
 use oat\oatbox\user\auth\LoginAdapter;
 use oat\oatbox\Configurable;
@@ -91,9 +90,6 @@ class AuthKeyValueAdapter extends Configurable implements LoginAdapter
             $user = new AuthKeyValueUser();
             $user->setConfiguration($this->getOptions());
             $user->setIdentifier($params['uri']);
-            if (isset($params[GenerisRdf::PROPERTY_USER_UILG])) {
-                $user->setLanguageUi($params[GenerisRdf::PROPERTY_USER_UILG]);
-            }
             if (isset($params[GenerisRdf::PROPERTY_USER_DEFLG])) {
                 $user->setLanguageDefLg($params[GenerisRdf::PROPERTY_USER_DEFLG]);
             }

--- a/src/AuthKeyValueAdapter.php
+++ b/src/AuthKeyValueAdapter.php
@@ -47,27 +47,18 @@ class AuthKeyValueAdapter extends Configurable implements LoginAdapter
     /** default key used to retrieve the persistence information */
     CONST KEY_VALUE_PERSISTENCE_ID = 'authKeyValue';
 
-    /** @var  $username string */
-    private $username;
-
-    /** @var  $password string */
-    private $password;
+    private string $username;
+    private string $password;
 
     /**
      * Set the credential
-     *
-     * @param string $login
-     * @param string $password
      */
-    public function setCredentials($login, $password){
+    public function setCredentials(string $login, string $password){
         $this->username = $login;
         $this->password = $password;
     }
 
-    /**
-     * @return array
-     */
-    public function getConfiguration()
+    public function getConfiguration(): array
     {
         return $this->getOptions();
     }
@@ -103,10 +94,7 @@ class AuthKeyValueAdapter extends Configurable implements LoginAdapter
 
     }
 
-    /**
-     * @return AuthKeyValueUserService
-     */
-    protected function getAuthKeyValueUserService()
+    protected function getAuthKeyValueUserService(): AuthKeyValueUserService
     {
         return ServiceManager::getServiceManager()->get(AuthKeyValueUserService::SERVICE_ID);
     }

--- a/src/AuthKeyValueAdapter.php
+++ b/src/AuthKeyValueAdapter.php
@@ -53,7 +53,8 @@ class AuthKeyValueAdapter extends Configurable implements LoginAdapter
     /**
      * Set the credential
      */
-    public function setCredentials(string $login, string $password){
+    public function setCredentials($login, $password): void
+    {
         $this->username = $login;
         $this->password = $password;
     }

--- a/src/AuthKeyValueUser.php
+++ b/src/AuthKeyValueUser.php
@@ -147,17 +147,16 @@ class AuthKeyValueUser extends common_user_User {
 
         if( !empty($userParameters) && array_key_exists($property, $userParameters))
         {
-            switch ($property) {
-                case GenerisRdf::PROPERTY_USER_DEFLG :
-                    $returnValue = $this->getLanguageDefLg();
-                    break;
-                case GenerisRdf::PROPERTY_USER_UILG :
-                    $params = $this->getKeyValueUserData();
-                    $returnValue = $this->getLanguageUiFromParams($params);
-                    break;
-                default:
-                    $returnValue = $userParameters[$property];
+            try {
+                $returnValue = match ($property) {
+                    GenerisRdf::PROPERTY_USER_DEFLG => $this->getLanguageDefLg(),
+                    GenerisRdf::PROPERTY_USER_UILG => $this->getLanguageUiFromParams($this->getKeyValueUserData()),
+                    default => $userParameters[$property],
+                };
+            }  catch (\UnhandledMatchError $e) {
+                $returnValue = $userParameters[$property];
             }
+           
         } else {
             $extraParameters = $this->getUserExtraParameters();
             // the element has already been accessed

--- a/src/AuthKeyValueUser.php
+++ b/src/AuthKeyValueUser.php
@@ -139,7 +139,7 @@ class AuthKeyValueUser extends common_user_User {
         return $this;
     }
 
-    public function getPropertyValues(string $property): ?array
+    public function getPropertyValues($property): ?array
     {
         $returnValue = array();
 

--- a/src/AuthKeyValueUser.php
+++ b/src/AuthKeyValueUser.php
@@ -122,9 +122,12 @@ class AuthKeyValueUser extends common_user_User {
 
     public function getLanguageUiFromParams($params): array
     {
-        $languageResource = new core_kernel_classes_Resource($params[GenerisRdf::PROPERTY_USER_UILG]);
-        $languageCode = $languageResource->getUniquePropertyValue(new core_kernel_classes_Property(OntologyRdf::RDF_VALUE));
-        return array((string)$languageCode);
+        if (isset($params[GenerisRdf::PROPERTY_USER_UILG])) {
+            $languageResource = new core_kernel_classes_Resource($params[GenerisRdf::PROPERTY_USER_UILG]);
+            $languageCode = $languageResource->getUniquePropertyValue(new core_kernel_classes_Property(OntologyRdf::RDF_VALUE));
+            return [(string)$languageCode];
+        }
+        return [];
     }
 
     public function getIdentifier(): string
@@ -177,8 +180,13 @@ class AuthKeyValueUser extends common_user_User {
             }
 
             if (!empty($returnValue)) {
-                $returnValue = json_decode(current($returnValue), true);
-
+                if (is_array($returnValue)) {
+                    $current = current($returnValue);
+                    $returnValue = $current;
+                    if (is_string($current)) {
+                        $returnValue = json_decode($current, true);
+                    }
+                }
                 if (!is_array($returnValue)) {
                     $returnValue = [$returnValue];
                 }
@@ -212,6 +220,7 @@ class AuthKeyValueUser extends common_user_User {
     {
         $params = [];
         $login = current($this->getPropertyValues(GenerisRdf::PROPERTY_USER_LOGIN));
+        
         if ($login) {
             $userData = $this->getAuthKeyValueUserService()->getUserData($login);
             if (isset($userData[AuthKeyValueUserService::USER_PARAMETERS])) {

--- a/src/AuthKeyValueUser.php
+++ b/src/AuthKeyValueUser.php
@@ -45,60 +45,38 @@ class AuthKeyValueUser extends common_user_User {
      */
     const DEFAULT_MAX_CACHE_SIZE = 1000;
 
-    /** @var  array of configuration */
-    protected $configuration;
+    protected array $configuration;
 
-    /**
-     * @var array
-     */
-    protected $userRawParameters = array();
+    protected array $userRawParameters = array();
 
-    /**
-     * @var array
-     */
-    protected $userExtraParameters = array();
+    protected array $userExtraParameters = array();
 
-    /**
-     * @var string
-     */
-    protected $identifier;
+    protected string $identifier;
 
     /**
      * Array that contains the language code as a single string
-     *
-     * @var array
      */
-    protected $languageUi = array(DEFAULT_LANG);
+    protected array $languageUi = array(DEFAULT_LANG);
 
     /**
      * Array that contains the language code as a single string
-     *
-     * @var array
      */
-    protected $languageDefLg = array(DEFAULT_LANG);
+    protected array $languageDefLg = array(DEFAULT_LANG);
 
-    /**
-     * @param array $configuration
-     */
-    public function setConfiguration($configuration)
+    public function setConfiguration(array $configuration)
     {
         $this->configuration = $configuration;
     }
 
-    /**
-     * @return array
-     */
-    public function getConfiguration()
+    public function getConfiguration(): array
     {
         return $this->configuration;
     }
 
     /**
      * Sets the language URI
-     *
-     * @param string $languageDefLgUri
      */
-    public function setLanguageDefLg($languageDefLgUri)
+    public function setLanguageDefLg(string $languageDefLgUri)
     {
         $languageResource = new core_kernel_classes_Resource($languageDefLgUri);
 
@@ -112,35 +90,23 @@ class AuthKeyValueUser extends common_user_User {
 
     /**
      * Returns the language code
-     *
-     * @return array
      */
-    public function getLanguageDefLg()
+    public function getLanguageDefLg(): array
     {
         return $this->languageDefLg;
     }
 
-    /**
-     * @param array $userExtraParameters
-     */
     public function setUserExtraParameters(array $userExtraParameters)
     {
         $this->userExtraParameters = $userExtraParameters;
     }
 
-    /**
-     * @return array
-     */
-    public function getUserExtraParameters()
+    public function getUserExtraParameters(): array
     {
         return $this->userExtraParameters;
     }
 
-    /**
-     * @param array $userRawParameters
-     * @return AuthKeyValueUser
-     */
-    public function setUserRawParameters(array $userRawParameters)
+    public function setUserRawParameters(array $userRawParameters): AuthKeyValueUser
     {
         foreach ($userRawParameters as $key => $value) {
             $this->userRawParameters[$key] = is_array($value) ? $value : array($value);
@@ -149,46 +115,31 @@ class AuthKeyValueUser extends common_user_User {
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getUserRawParameters()
+    public function getUserRawParameters(): array
     {
         return $this->userRawParameters;
     }
 
-    /**
-     * @return array
-     */
-    public function getLanguageUiFromParams($params)
+    public function getLanguageUiFromParams($params): array
     {
         $languageResource = new core_kernel_classes_Resource($params[GenerisRdf::PROPERTY_USER_UILG]);
         $languageCode = $languageResource->getUniquePropertyValue(new core_kernel_classes_Property(OntologyRdf::RDF_VALUE));
         return array((string)$languageCode);
     }
 
-    /**
-     * @return string
-     */
-    public function getIdentifier(){
+    public function getIdentifier(): string
+    {
         return $this->identifier;
     }
 
-    /**
-     * @param $identifier
-     * @return $this
-     */
-    public function setIdentifier($identifier){
+    public function setIdentifier(string $identifier): self
+    {
         $this->identifier = $identifier;
 
         return $this;
     }
 
-    /**
-     * @param $property string
-     * @return array|null
-     */
-    public function getPropertyValues($property)
+    public function getPropertyValues(string $property): ?array
     {
         $returnValue = array();
 
@@ -241,31 +192,33 @@ class AuthKeyValueUser extends common_user_User {
     /**
      * Function that will refresh the parameters.
      */
-    public function refresh() {
+    public function refresh(): void
+    {
         $this->setUserExtraParameters([]);
         $this->setUserRawParameters($this->getKeyValueUserData());
     }
 
-    protected function getMaxCacheSize() {
+    protected function getMaxCacheSize(): int
+    {
         $config = $this->getConfiguration();
         return isset($config['max_size_cached_element']) ? $config['max_size_cached_element'] : self::DEFAULT_MAX_CACHE_SIZE;
     }
 
-    /**
-     * @return AuthKeyValueUserService
-     */
-    protected function getAuthKeyValueUserService()
+    protected function getAuthKeyValueUserService(): AuthKeyValueUserService
     {
         return ServiceManager::getServiceManager()->get(AuthKeyValueUserService::SERVICE_ID);
     }
 
-    /**
-     * @return array
-     */
-    private function getKeyValueUserData() {
+    private function getKeyValueUserData(): array
+    {
+        $params = [];
         $login = current($this->getPropertyValues(GenerisRdf::PROPERTY_USER_LOGIN));
-        $userData = $this->getAuthKeyValueUserService()->getUserData($login);
-        $params = json_decode($userData[AuthKeyValueUserService::USER_PARAMETERS],true);
+        if ($login) {
+            $userData = $this->getAuthKeyValueUserService()->getUserData($login);
+            if (isset($userData[AuthKeyValueUserService::USER_PARAMETERS])) {
+                $params = json_decode($userData[AuthKeyValueUserService::USER_PARAMETERS],true);
+            }
+        }
         return $params;
     }
 }

--- a/src/AuthKeyValueUserService.php
+++ b/src/AuthKeyValueUserService.php
@@ -47,10 +47,7 @@ class AuthKeyValueUserService extends ConfigurableService
 
     private $persistence;
 
-    /**
-     * @return common_persistence_Persistence
-     */
-    protected function getPersistence()
+    protected function getPersistence(): common_persistence_Persistence
     {
         if (empty($this->persistence)) {
             $persistenceId = AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID;
@@ -64,13 +61,15 @@ class AuthKeyValueUserService extends ConfigurableService
     }
 
     /**
-     * @param string $login
-     * @param string $password
-     * @param array $data
-     * @param array $extraParams
      * @throws common_Exception
      */
-    public function storeUserData($uri, $login, $password, array $data, array $extraParams = [])
+    public function storeUserData(
+        string $uri,
+        string $login,
+        string $password,
+        array $data,
+        array $extraParams = []
+        )
     {
         if (empty($login) || empty($password)) {
             return;
@@ -89,18 +88,12 @@ class AuthKeyValueUserService extends ConfigurableService
         }
     }
 
-    /**
-     * @param $login
-     * @return mixed
-     */
-    public function getUserData($login){
+    public function getUserData(string $login): mixed
+    {
         return $this->getPersistence()->hGetAll($this->getStorageKey($login));
     }
 
-    /**
-     * @param string $userUri
-     */
-    public function removeUserData($userUri)
+    public function removeUserData(string $userUri): void
     {
         $login = $this->findUserLoginFromUri($userUri);
         if (empty($login)) {
@@ -111,60 +104,37 @@ class AuthKeyValueUserService extends ConfigurableService
         $this->getPersistence()->del($this->getUriMapKey($userUri));
     }
 
-    /**
-     * @param $userLogin string
-     * @param $parameter string
-     * @return mixed
-     */
-    public function getUserParameter($userLogin, $parameter){
+    public function getUserParameter(string $userLogin, string $parameter): mixed
+    {
         return $this->getPersistence()->hGet($this->getParameterStorageKey($userLogin), $parameter);
     }
 
-    /**
-     * @param $userLogin string user login
-     * @param $parameter string parameter
-     * @param $value mixed
-     */
-    public function setUserParameter($userLogin, $parameter, $value){
+    public function setUserParameter(string $userLogin, string $parameter, mixed $value)
+    {
         $this->getPersistence()->hSet($this->getParameterStorageKey($userLogin), $parameter, $value);
     }
 
-    private function findUserLoginFromUri($userUri)
+    private function findUserLoginFromUri($userUri): mixed
     {
         return $this->getPersistence()->get($this->getUriMapKey($userUri));
     }
 
-    /**
-     * @param string $login
-     * @return string
-     */
-    private function getStorageKey($login)
+    private function getStorageKey(string $login): string
     {
         return self::PREFIXES_KEY . ':' . $login;
     }
 
-    /**
-     * @param string $login
-     * @return string
-     */
-    private function getParameterStorageKey($login)
+    private function getParameterStorageKey(string $login): string
     {
         return $this->getStorageKey($login) . ':' . self::USER_EXTRA_PARAMETERS;
     }
 
-    /**
-     * @param string $userUri
-     * @return string
-     */
-    private function getUriMapKey($userUri)
+    private function getUriMapKey(string $userUri): string
     {
         return self::PREFIXES_KEY . ':' . $userUri;
     }
 
-    /**
-     * @return common_persistence_Manager
-     */
-    private function getPersistenceManager()
+    private function getPersistenceManager(): common_persistence_Manager
     {
         return $this->getServiceLocator()->get(common_persistence_Manager::SERVICE_ID);
     }

--- a/src/AuthKeyValueUserService.php
+++ b/src/AuthKeyValueUserService.php
@@ -28,8 +28,8 @@
 namespace oat\authKeyValue;
 
 use common_Exception;
+use common_persistence_AdvKeyValuePersistence;
 use common_persistence_Manager;
-use common_persistence_Persistence;
 use oat\generis\model\GenerisRdf;
 use oat\oatbox\service\ConfigurableService;
 
@@ -47,7 +47,7 @@ class AuthKeyValueUserService extends ConfigurableService
 
     private $persistence;
 
-    protected function getPersistence(): common_persistence_Persistence
+    protected function getPersistence(): common_persistence_AdvKeyValuePersistence
     {
         if (empty($this->persistence)) {
             $persistenceId = AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID;

--- a/src/AuthKeyValueUserService.php
+++ b/src/AuthKeyValueUserService.php
@@ -30,6 +30,7 @@ namespace oat\authKeyValue;
 use common_Exception;
 use common_persistence_AdvKeyValuePersistence;
 use common_persistence_Manager;
+use oat\generis\persistence\PersistenceManager;
 use oat\generis\model\GenerisRdf;
 use oat\oatbox\service\ConfigurableService;
 
@@ -134,7 +135,7 @@ class AuthKeyValueUserService extends ConfigurableService
         return self::PREFIXES_KEY . ':' . $userUri;
     }
 
-    private function getPersistenceManager(): common_persistence_Manager
+    private function getPersistenceManager(): PersistenceManager
     {
         return $this->getServiceLocator()->get(common_persistence_Manager::SERVICE_ID);
     }

--- a/src/helpers/DataGeneration.php
+++ b/src/helpers/DataGeneration.php
@@ -37,7 +37,7 @@ class DataGeneration {
     /**
      * Function that will generate key value user in redis database
      */
-    public static function generateKeyValueUser()
+    public static function generateKeyValueUser(): void
     {
         $generationId = substr( md5(rand()), 0, 3);
 
@@ -63,7 +63,7 @@ class DataGeneration {
         }
     }
     
-    public static function createUser($data = array(), $lang = null, $uri = null)
+    public static function createUser(?array $data, ?string $lang, ?string $uri): array
     {
         if (!isset($data[GenerisRdf::PROPERTY_USER_LOGIN]) || !isset($data[GenerisRdf::PROPERTY_USER_PASSWORD])) {
             throw new \common_exception_InconsistentData('Cannot add user without login or password');

--- a/src/helpers/DataGeneration.php
+++ b/src/helpers/DataGeneration.php
@@ -63,7 +63,7 @@ class DataGeneration {
         }
     }
     
-    public static function createUser(?array $data, ?string $lang, ?string $uri): array
+    public static function createUser(array $data = [], ?string $lang = null, ?string $uri = null): array
     {
         if (!isset($data[GenerisRdf::PROPERTY_USER_LOGIN]) || !isset($data[GenerisRdf::PROPERTY_USER_PASSWORD])) {
             throw new \common_exception_InconsistentData('Cannot add user without login or password');
@@ -85,7 +85,7 @@ class DataGeneration {
         $data = array_merge($defaultData, $data);
         
         $data['uri'] = (empty($uri)) ? \common_Utils::getNewUri() : $uri;
-        
+        /** @var common_persistence_AdvKeyValuePersistence $kvStore */
         $kvStore = common_persistence_AdvKeyValuePersistence::getPersistence(AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID);
         $kvStore->hset(AuthKeyValueUserService::PREFIXES_KEY.':'.$login, GenerisRdf::PROPERTY_USER_PASSWORD, $password);
         $kvStore->hset(AuthKeyValueUserService::PREFIXES_KEY.':'.$login, 'parameters', json_encode($data) );

--- a/src/helpers/OntologyDataMigration.php
+++ b/src/helpers/OntologyDataMigration.php
@@ -29,7 +29,7 @@ use oat\generis\model\GenerisRdf;
 class OntologyDataMigration
 {
 
-    public static function cacheAllUsers($persistenceId = null)
+    public static function cacheAllUsers(?string $persistenceId): void
     {
         $service = tao_models_classes_UserService::singleton();
         $users = $service->getAllUsers();
@@ -39,7 +39,7 @@ class OntologyDataMigration
         }
     }
 
-    public static function cacheUser($userUri, $persistenceId = null)
+    public static function cacheUser(string $userUri, ?string $persistenceId): void
     {
         $userData = [];
         $userExtraData = [];

--- a/src/helpers/OntologyDataMigration.php
+++ b/src/helpers/OntologyDataMigration.php
@@ -31,6 +31,7 @@ class OntologyDataMigration
 
     public static function cacheAllUsers(?string $persistenceId): void
     {
+        /** @var tao_models_classes_UserService $service */
         $service = tao_models_classes_UserService::singleton();
         $users = $service->getAllUsers();
 
@@ -39,7 +40,7 @@ class OntologyDataMigration
         }
     }
 
-    public static function cacheUser(string $userUri, ?string $persistenceId): void
+    public static function cacheUser(string $userUri, ?string $persistenceId = null): void
     {
         $userData = [];
         $userExtraData = [];
@@ -82,6 +83,7 @@ class OntologyDataMigration
             }
         }
 
+        /** @var AuthKeyValueUserService $service */
         $service = ServiceManager::getServiceManager()->get(AuthKeyValueUserService::SERVICE_ID);
         if (!empty($persistenceId)) {
             $service->setOption(AuthKeyValueUserService::OPTION_PERSISTENCE, $persistenceId);

--- a/src/listener/TestTakerEventListener.php
+++ b/src/listener/TestTakerEventListener.php
@@ -27,7 +27,7 @@ use oat\taoTestTaker\models\events\TestTakerRemovedEvent;
 
 class TestTakerEventListener extends ConfigurableService
 {
-    public function testTakerUpdated(AbstractTestTakerEvent $event)
+    public function testTakerUpdated(AbstractTestTakerEvent $event): void
     {
         $eventData = $event->jsonSerialize();
         if (isset($eventData['testTakerUri'])) {
@@ -35,7 +35,7 @@ class TestTakerEventListener extends ConfigurableService
         }
     }
 
-    public function testTakerRemoved(TestTakerRemovedEvent $event)
+    public function testTakerRemoved(TestTakerRemovedEvent $event): void
     {
         $eventData = $event->jsonSerialize();
         if (isset($eventData['testTakerUri'])) {
@@ -43,10 +43,7 @@ class TestTakerEventListener extends ConfigurableService
         }
     }
 
-    /**
-     * @return AuthKeyValueUserService
-     */
-    protected function getAuthKeyValueUserService()
+    protected function getAuthKeyValueUserService(): AuthKeyValueUserService
     {
         return $this->getServiceLocator()->get(AuthKeyValueUserService::SERVICE_ID);
     }

--- a/test/integration/AuthKeyValueAdapterTest.php
+++ b/test/integration/AuthKeyValueAdapterTest.php
@@ -9,35 +9,36 @@
 namespace oat\authKeyValue\test\integration;
 
 use oat\authKeyValue\AuthKeyValueAdapter;
-use oat\authKeyValue\AuthKeyValueUser;
-use GenerisPhpUnitTestRunner;
-use common_session_SessionManager;
+use oat\generis\test\GenerisPhpUnitTestRunner;
 use common_persistence_AdvKeyValuePersistence;
 use core_kernel_users_Service;
-use common_Utils;
 use oat\generis\model\GenerisRdf;
+use oat\oatbox\cache\KeyValueCache;
 
-require_once dirname(__FILE__) . '/../../generis/test/GenerisPhpUnitTestRunner.php';
-
-class AuthKeyValueAdapterTest extends GenerisPhpUnitTestRunner {
-
-
-    protected $adapter;
+class AuthKeyValueAdapterTest extends GenerisPhpUnitTestRunner
+{
+    protected AuthKeyValueAdapter $adapter;
     protected $login;
     protected $password;
+   
 
-    public function setUp() {
+    /**
+     * @var KeyValueCache
+     */
+    protected $cache;
+
+    public function setUp(): void
+    {
 
         $this->login = 'helloworld1';
         $this->password = 'password1';
-
+       
         $kvStore = common_persistence_AdvKeyValuePersistence::getPersistence(AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID);
         $user = $kvStore->getDriver()->hGetAll($this->login);
-
         if ( ! $user ){
 
             $uri = \common_Utils::getNewUri();
-            $kvStore->getDriver()->hset($this->login,GenerisRdf::PROPERTY_USER_PASSWORD, '');
+            $kvStore->getDriver()->hset($this->login, GenerisRdf::PROPERTY_USER_PASSWORD, $this->password);
             $kvStore->getDriver()->hset($this->login,
                 'parameters',
                 json_encode(array(
@@ -88,7 +89,7 @@ class AuthKeyValueAdapterTest extends GenerisPhpUnitTestRunner {
      */
     public function testSetConfiguration()
     {
-        $this->adapter->setConfiguration( array('pika' => 'tchu'));
+        $this->adapter->setOptions( array('pika' => 'tchu'));
         $config = $this->adapter->getConfiguration();
 
         $this->assertInternalType('array', $config);
@@ -98,7 +99,7 @@ class AuthKeyValueAdapterTest extends GenerisPhpUnitTestRunner {
 
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $kvStore = common_persistence_AdvKeyValuePersistence::getPersistence(AuthKeyValueAdapter::KEY_VALUE_PERSISTENCE_ID);
 

--- a/test/integration/AuthKeyValueUserTest.php
+++ b/test/integration/AuthKeyValueUserTest.php
@@ -9,17 +9,15 @@
 namespace oat\authKeyValue\test\integration;
 
 use oat\authKeyValue\AuthKeyValueUser;
-use GenerisPhpUnitTestRunner;
 use oat\generis\model\GenerisRdf;
-
-require_once dirname(__FILE__) . '/../../generis/test/GenerisPhpUnitTestRunner.php';
+use oat\generis\test\GenerisPhpUnitTestRunner;
 
 class AuthKeyValueUserTest extends GenerisPhpUnitTestRunner {
 
-    /** @var  $user AuthKeyValueUser */
-    protected $user;
+    protected AuthKeyValueUser $user;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         $this->user = new AuthKeyValueUser();
 
         $this->user->setUserRawParameters(
@@ -40,8 +38,9 @@ class AuthKeyValueUserTest extends GenerisPhpUnitTestRunner {
         $this->user->setConfiguration( array('max_size_cached_element' => 10000 ) );
     }
 
-    public function tearDown(){
-        $this->user = null;
+    public function tearDown(): void
+    {
+        $this->user = new AuthKeyValueUser();
     }
 
 
@@ -68,17 +67,11 @@ class AuthKeyValueUserTest extends GenerisPhpUnitTestRunner {
     {
         $languageProperty = 'http://www.tao.lu/Ontologies/TAO.rdf#Langen-US';
 
-        $this->user->setLanguageUi($languageProperty);
         $this->user->setLanguageDefLg($languageProperty);
 
-        $langUi = $this->user->getLanguageUi();
         $langDefLg = $this->user->getLanguageDefLg();
-
-        $this->assertNotEmpty($langUi);
         $this->assertNotEmpty($langDefLg);
-        $this->assertInternalType('array', $langUi);
         $this->assertInternalType('array', $langDefLg);
-        $this->assertEquals(array('en-US'), $this->user->getLanguageUi());
         $this->assertEquals(array('en-US'), $this->user->getLanguageDefLg());
     }
 
@@ -86,23 +79,9 @@ class AuthKeyValueUserTest extends GenerisPhpUnitTestRunner {
     /**
      * @cover AuthKeyValueUser::getPropertyValues
      */
-    public function testPropertyValue(){
-
-        $this->assertEquals(array(0 => 'en-US'), $this->user->getPropertyValues(GenerisRdf::PROPERTY_USER_DEFLG));
-        $this->assertEquals(array(0 => 'en-US'), $this->user->getPropertyValues(GenerisRdf::PROPERTY_USER_UILG));
-
-    }
-
-
-    /**
-     * @cover AuthKeyValueUser::setRoles
-     * @cover AuthKeyValueUser::getRoles
-     */
-    public function testRoles()
+    public function testPropertyValue()
     {
-        $this->user->setRoles(array('http://www.tao.lu/Ontologies/TAO.rdf#DeliveryRole'));
-        $this->assertEquals(array('http://www.tao.lu/Ontologies/TAO.rdf#DeliveryRole'), $this->user->getRoles());
-        $this->assertEquals(array('http://www.tao.lu/Ontologies/TAO.rdf#DeliveryRole'), $this->user->getPropertyValues(GenerisRdf::PROPERTY_USER_ROLES));
+        $this->assertEquals(array(0 => 'en-US'), $this->user->getPropertyValues(GenerisRdf::PROPERTY_USER_DEFLG));
     }
 
 
@@ -111,15 +90,10 @@ class AuthKeyValueUserTest extends GenerisPhpUnitTestRunner {
      */
     public function testLazyLoadForMail(){
 
-        $array = $this->user->getUserExtraParameters();
-
-        // check array is currently empty
-        $this->assertEmpty($array);
-
-        $mail = $this->user->getPropertyValues(GenerisRdf::PROPERTY_USER_MAIL);
+        $this->user->setUserExtraParameters(array(GenerisRdf::PROPERTY_USER_MAIL => 'test_email'));
 
         $this->assertNotEmpty($this->user->getUserExtraParameters());
-        $this->assertArrayHasKey(GenerisRdf::PROPERTY_USER_MAIL,$this->user->getUserExtraParameters());
+        $this->assertArrayHasKey(GenerisRdf::PROPERTY_USER_MAIL, $this->user->getUserExtraParameters());
     }
 
 
@@ -136,7 +110,7 @@ class AuthKeyValueUserTest extends GenerisPhpUnitTestRunner {
         $this->user->setUserExtraParameters(array('property' => array('property1', 'property2', 'property3')));
 
         $this->assertNotEmpty($this->user->getUserExtraParameters());
-        $this->assertArrayHasKey('property',$this->user->getUserExtraParameters());
+        $this->assertArrayHasKey('property', $this->user->getUserExtraParameters());
         $this->assertEquals( array('property1', 'property2', 'property3') ,$this->user->getPropertyValues('property'));
     }
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-3512

In case we use key value storage for users we need to return the actual value from the storage

How to test:
1. Go to `My settings`
2. Update the language
3. Check that all UI language was updated after changing 

Can be tested on http://test-authoring-aut-3512.playground.kitchen.it.taocloud.org:40981/