### PR TITLE
fix: use UserInternalInterface for key value users

### DIFF
--- a/src/AuthKeyValueUser.php
+++ b/src/AuthKeyValueUser.php
@@ -35,8 +35,9 @@ use core_kernel_classes_Property;
 use oat\generis\model\OntologyRdf;
 use oat\generis\model\GenerisRdf;
 use oat\oatbox\service\ServiceManager;
+use oat\generis\model\kernel\users\UserInternalInterface;
 
-class AuthKeyValueUser extends common_user_User {
+class AuthKeyValueUser extends common_user_User implements UserInternalInterface{
 
     /**
      * Max size of a property to store in the session in characters


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-5992

Implement the UserInternalInterface interface for solving issues with getting sessions from assigned test centers

https://github.com/oat-sa/extension-tao-testcenter/blob/master/model/proctoring/TestCenterProctorService.php#L77

How to test:
1. Create a test center with deliveries and test takers
2. Create a test center admin user with next sets of roles `Proctor, Proctor Administrator, Test Center Administrator Role`
3. Assign the admin users to the created test center
4. Login by the admin of the test center
